### PR TITLE
document timeperiod for /reports

### DIFF
--- a/routes/reports.md
+++ b/routes/reports.md
@@ -10,7 +10,7 @@ Live disaster reports, by default reports will be returned for the last hour.
 | city | Which city do we wish to return infrastructure for? (one of `bdg`, `jbd`, `sby`) | String | No |
 | format | Which format should we return results in? (one of `json`, defaults to `json`) | String | No |
 | geoformat | What format should geographic results use (one of `topojson`, `geojson` defaults to `topojson`) | String | No |
-
+| timeperiod | What time period (in seconds) to list reports for, must be strictly between 1 and 604800 (1 week) | Number | No | 
 
 {% method %}
 ### GET /reports
@@ -83,6 +83,3 @@ Results are as follows:
 ```
 
 {% endmethod %}
-
-
-

--- a/routes/stats/reportsSummary.md
+++ b/routes/stats/reportsSummary.md
@@ -1,7 +1,5 @@
 ## Stats (reports summary)
 
-Note: currently inactive pending some changes to the /reports API.
-
 Count of reports by source ("qlue" for Qlue, "detik" for Detik Pasangmata, or "grasp" being combined Twitter and Telegram), by default reports will be returned for the last hour.
 
 


### PR DESCRIPTION
corresponds to https://github.com/urbanriskmap/cognicity-server-v3/pull/16